### PR TITLE
Fix all projects being filtered.

### DIFF
--- a/cmd/contempt/main.go
+++ b/cmd/contempt/main.go
@@ -46,7 +46,7 @@ func main() {
 	filtered := strings.Split(*filter, ",")
 
 	for i := range projects {
-		if len(filtered) == 0 || slices.Contains(filtered, projects[i]) {
+		if (len(filtered) == 1 && filtered[0] == "") || slices.Contains(filtered, projects[i]) {
 			if *workflowCommands {
 				fmt.Printf("::group::%s\n", projects[i])
 			}


### PR DESCRIPTION
Strings.split returns a slice with size 1 if there are no matches.