### PR TITLE
Remove buildah version from images

### DIFF
--- a/cmd/contempt/main.go
+++ b/cmd/contempt/main.go
@@ -76,6 +76,7 @@ func main() {
 					"--timestamp",
 					"0",
 					"--layers",
+					"--identity-label=false",
 					"--tag",
 					imageName,
 					filepath.Join(flag.Arg(1), projects[i]),


### PR DESCRIPTION
The version of buildah no used by github supports this, so its probably safe to just use by default